### PR TITLE
fix: Move st.set_page_config() to be first Streamlit command

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -16,6 +16,13 @@ from requests.exceptions import ConnectionError, Timeout, RequestException
 from urllib3.exceptions import ProtocolError
 from http.client import RemoteDisconnected
 
+# Page configuration (must be first Streamlit command)
+st.set_page_config(
+    page_title="Portfolio Simulation Dashboard",
+    page_icon="📈",
+    layout="wide",
+    initial_sidebar_state="expanded"
+)
 
 # Configure logging
 @st.cache_resource
@@ -51,14 +58,6 @@ def setup_logging():
 # Initialize logger
 logger = setup_logging()
 
-
-# Page configuration
-st.set_page_config(
-    page_title="Portfolio Simulation Dashboard",
-    page_icon="📈",
-    layout="wide",
-    initial_sidebar_state="expanded"
-)
 
 # Custom CSS for better styling
 st.markdown("""


### PR DESCRIPTION
- Resolved StreamlitSetPageConfigMustBeFirstCommandError
- Moved page configuration immediately after imports
- Removed duplicate st.set_page_config() call
- Ensures proper Streamlit initialization order
